### PR TITLE
Migrate to Material You and some misc changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 	<uses-permission android:name="android.permission.INTERNET" />
 	<application
 		android:allowBackup="true"
+		android:name=".core.CoreApplication"
 		android:icon="@mipmap/ic_launcher"
 		android:label="Unalix"
 		android:theme="@style/AppTheme">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,7 +64,8 @@
 		<activity
 			android:label="Unalix"
 			android:name=".activities.MainActivity"
-			android:exported="true" >
+			android:exported="true"
+			android:windowSoftInputMode="adjustResize" >
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/amanoteam/unalix/activities/MainActivity.java
+++ b/app/src/main/java/com/amanoteam/unalix/activities/MainActivity.java
@@ -20,7 +20,6 @@ import com.amanoteam.unalix.utilities.PackageUtils;
 import com.amanoteam.unalix.wrappers.Unalix;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.textfield.TextInputEditText;
 
 

--- a/app/src/main/java/com/amanoteam/unalix/activities/MainActivity.java
+++ b/app/src/main/java/com/amanoteam/unalix/activities/MainActivity.java
@@ -13,12 +13,12 @@ import android.view.MenuItem;
 import android.view.View;
 
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 import androidx.preference.PreferenceManager;
 
 import com.amanoteam.unalix.R;
 import com.amanoteam.unalix.utilities.PackageUtils;
 import com.amanoteam.unalix.wrappers.Unalix;
+import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.textfield.TextInputEditText;
@@ -44,11 +44,6 @@ public class MainActivity extends AppCompatActivity {
 		// Preferences stuff
 		final SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(this);
 		settings.registerOnSharedPreferenceChangeListener(onSharedPreferenceChangeListener);
-
-		// Dark mode stuff
-		final String appTheme = settings.getString("appTheme", "follow_system");
-
-		PackageUtils.setAppTheme(appTheme);
 
 		super.onCreate(savedInstanceState);
 
@@ -148,7 +143,7 @@ public class MainActivity extends AppCompatActivity {
 		});
 
 		// Action bar stuff
-		final Toolbar toolbar = (Toolbar) findViewById(R.id.main_toolbar);
+		final MaterialToolbar toolbar = findViewById(R.id.main_toolbar);
 		setSupportActionBar(toolbar);
 
 		// libunalix stuff

--- a/app/src/main/java/com/amanoteam/unalix/activities/SettingsActivity.java
+++ b/app/src/main/java/com/amanoteam/unalix/activities/SettingsActivity.java
@@ -17,7 +17,6 @@ import android.view.MenuItem;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 import androidx.preference.PreferenceManager;
 import androidx.preference.PreferenceScreen;
 import androidx.preference.EditTextPreference;
@@ -27,6 +26,7 @@ import androidx.preference.ListPreference;
 import com.amanoteam.unalix.R;
 import com.amanoteam.unalix.fragments.SettingsFragment;
 import com.amanoteam.unalix.utilities.PackageUtils;
+import com.google.android.material.appbar.MaterialToolbar;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -232,7 +232,7 @@ public class SettingsActivity extends AppCompatActivity {
 		setContentView(R.layout.activity_settings);
 
 		// Action bar
-		final Toolbar toolbar = (Toolbar) findViewById(R.id.settings_toolbar);
+		final MaterialToolbar toolbar = findViewById(R.id.settings_toolbar);
 		setSupportActionBar(toolbar);
 
 		settingsFragment = new SettingsFragment();

--- a/app/src/main/java/com/amanoteam/unalix/core/CoreApplication.java
+++ b/app/src/main/java/com/amanoteam/unalix/core/CoreApplication.java
@@ -1,0 +1,25 @@
+package com.amanoteam.unalix.core;
+
+import android.app.Application;
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+
+import com.amanoteam.unalix.utilities.PackageUtils;
+import com.google.android.material.color.DynamicColors;
+
+public class CoreApplication extends Application {
+	@Override
+	public void onCreate() {
+		super.onCreate();
+
+		final SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(this);
+
+		// Dark mode stuff
+		final String appTheme = settings.getString("appTheme", "follow_system");
+
+		PackageUtils.setAppTheme(appTheme);
+
+		DynamicColors.applyToActivitiesIfAvailable(this);
+	}
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,13 +3,11 @@
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	android:id="@+id/content_main"
 	android:layout_width="match_parent"
-	android:layout_height="match_parent"
-	android:fitsSystemWindows="true">
+	android:layout_height="match_parent">
 
 	<com.google.android.material.appbar.AppBarLayout
 		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:fitsSystemWindows="true">
+		android:layout_height="wrap_content">
 
 		<com.google.android.material.appbar.MaterialToolbar
 			android:id="@+id/main_toolbar"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,36 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	android:id="@+id/content_main"
 	android:layout_width="match_parent"
-	android:layout_height="match_parent">
+	android:layout_height="match_parent"
+	android:fitsSystemWindows="true">
 
 	<com.google.android.material.appbar.AppBarLayout
-		android:id="@+id/main_toolbar_layout"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
-		app:layout_constraintTop_toTopOf="parent">
+		android:fitsSystemWindows="true">
 
 		<com.google.android.material.appbar.MaterialToolbar
 			android:id="@+id/main_toolbar"
-			style="@style/Widget.MaterialComponents.Toolbar.Primary"
 			android:layout_width="match_parent"
 			android:layout_height="?attr/actionBarSize" />
 	</com.google.android.material.appbar.AppBarLayout>
 
 	<androidx.core.widget.NestedScrollView
 		android:layout_width="match_parent"
-		android:layout_height="0dp"
-		app:layout_constraintEnd_toEndOf="parent"
-		app:layout_constraintStart_toStartOf="parent"
-		app:layout_constraintTop_toBottomOf="@id/main_toolbar_layout">
+		android:layout_height="wrap_content"
+		android:layout_gravity="center_vertical"
+		app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
 		<androidx.constraintlayout.widget.ConstraintLayout
 			android:id="@+id/constraint_main"
 			android:layout_width="match_parent"
-			android:layout_height="0dp"
-			android:orientation="vertical"
-			app:layout_constraintTop_toBottomOf="@id/main_toolbar_layout">
+			android:layout_height="wrap_content"
+			android:orientation="vertical">
 
 			<com.google.android.material.textfield.TextInputLayout
 				android:id="@+id/url_layout"
@@ -109,4 +106,4 @@
 				app:srcCompat="@drawable/outline_clear_24" />
 		</androidx.constraintlayout.widget.ConstraintLayout>
 	</androidx.core.widget.NestedScrollView>
-</androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
-	android:orientation="vertical">
+	android:fitsSystemWindows="true">
 
 	<com.google.android.material.appbar.AppBarLayout
 		android:layout_width="match_parent"
-		android:layout_height="wrap_content">
+		android:layout_height="wrap_content"
+		android:fitsSystemWindows="true">
 
 		<com.google.android.material.appbar.MaterialToolbar
 			android:id="@+id/settings_toolbar"
-			style="@style/Widget.MaterialComponents.Toolbar.Primary"
 			android:layout_width="match_parent"
 			android:layout_height="?attr/actionBarSize" />
 	</com.google.android.material.appbar.AppBarLayout>
 
-	<FrameLayout
-		android:id="@+id/frame_layout_settings"
+	<androidx.core.widget.NestedScrollView
 		android:layout_width="match_parent"
-		android:layout_height="match_parent" />
-</LinearLayout>
+		android:layout_height="match_parent"
+		app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+		<FrameLayout
+			android:id="@+id/frame_layout_settings"
+			android:layout_width="match_parent"
+			android:layout_height="match_parent" />
+
+	</androidx.core.widget.NestedScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values-v23/styles.xml
+++ b/app/src/main/res/values-v23/styles.xml
@@ -1,0 +1,7 @@
+<resources>
+
+	<style name="AppTheme" parent="AppBaseTheme">
+		<item name="android:statusBarColor">@android:color/transparent</item>
+		<item name="android:windowLightStatusBar">?attr/isLightTheme</item>
+	</style>
+</resources>

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,0 +1,10 @@
+<resources>
+
+	<style name="AppTheme" parent="AppBaseTheme">
+		<item name="android:statusBarColor">@android:color/transparent</item>
+		<item name="android:windowLightStatusBar">?attr/isLightTheme</item>
+
+		<item name="android:navigationBarColor">@android:color/transparent</item>
+		<item name="android:windowLightNavigationBar">?attr/isLightTheme</item>
+	</style>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,8 +1,9 @@
 <resources>
 
-	<style name="AppTheme" parent="@style/Theme.Material3.DayNight.NoActionBar">
+	<style name="AppBaseTheme" parent="@style/Theme.Material3.DayNight.NoActionBar">
 		<item name="android:windowAnimationStyle">@android:style/Animation</item>
 		<item name="android:windowDisablePreview">true</item>
-		<item name="android:statusBarColor">@android:color/transparent</item>
 	</style>
+
+	<style name="AppTheme" parent="AppBaseTheme" />
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,9 @@
 <resources>
 
-	<style name="AppTheme" parent="@style/Theme.MaterialComponents.DayNight.NoActionBar">
+	<style name="AppTheme" parent="@style/Theme.Material3.DayNight.NoActionBar">
 		<item name="android:windowAnimationStyle">@android:style/Animation</item>
 		<item name="android:windowDisablePreview">true</item>
+		<item name="android:windowDrawsSystemBarBackgrounds">true</item>
+		<item name="android:statusBarColor">@android:color/transparent</item>
 	</style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -3,7 +3,6 @@
 	<style name="AppTheme" parent="@style/Theme.Material3.DayNight.NoActionBar">
 		<item name="android:windowAnimationStyle">@android:style/Animation</item>
 		<item name="android:windowDisablePreview">true</item>
-		<item name="android:windowDrawsSystemBarBackgrounds">true</item>
 		<item name="android:statusBarColor">@android:color/transparent</item>
 	</style>
 </resources>


### PR DESCRIPTION
# Purpose
- This PR is mainly for bringing up Material You and dynamic colors (introduced in Android 12) to the app.
- It also includes some fixes like setting `android:windowSoftInputMode="adjustResize"` to MainActivity, so that snackbars won't draw below soft keyboard anymore.
- Re-center widgets (Was removed due to scrolling issues in small screens (923344e69492f5b95d66d6a82d87c808bad7a005)).
- I also did migrate from `ConstraintLayout` back to a `CoordinatorLayout` in activity_main.xml, since now there's a proper fix for scrolling in small screens (923344e69492f5b95d66d6a82d87c808bad7a005) included in this PR.

**Note:** In order to comply more strictly to Material You (and therefore Material Design), the app probably needs a new UI too (which is not included in this PR) with some changes like converting the Settings Activity to a Fragment and accessing it using a [Navigation bar](https://m3.material.io/components/navigation-bar/overview) and reorganizing buttons in Main Activity (Feedback about this is welcome).

**Note 2:** About the the last (X) button having clipped shadows in the bottom (especially in light mode): This is a known issue present before this change, although in Material You shadows are bigger, making it more perceptible. This issue is also related to a scrolling issue, in which the view cannot scroll below ~50% of the last (X) button.

## Screenshots
<p><img src="https://user-images.githubusercontent.com/29029632/162604492-c6879bed-efe6-4b9c-b548-3b6d9ea41669.png" alt="Dark mode, Main Activity" height="720"/>
<img src="https://user-images.githubusercontent.com/29029632/162604491-7fe3b8fa-9770-48e2-b21d-7d01d35a8ce8.png" alt="Dark mode, Settings Activity" height="720"/></p>
<p><img src="https://user-images.githubusercontent.com/29029632/162604490-8af4ac7b-b4f5-46b8-b2fc-94bb9ec3d211.png" alt="Light mode, Main Activity" height="720"/>
<img src="https://user-images.githubusercontent.com/29029632/162604489-8ac2aa2c-d160-4ecc-b59e-ee573728a710.png" alt="Light mode, Settings Activity" height="720"/></p>
