### PR TITLE
grammar fixes

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -100,7 +100,7 @@
 		<CheckBoxPreference
 			android:defaultValue="false"
 			android:key="proxyAuthentication"
-			android:summary="A SOCKS5 server may required you to provide some credentials before connecting to it"
+			android:summary="A SOCKS5 server may require you to provide some credentials before connecting to it"
 			android:title="Authentication" />
 		<EditTextPreference
 			android:enabled="false"
@@ -121,7 +121,7 @@
 			android:entries="@array/app_theme_entries"
 			android:entryValues="@array/app_theme_values"
 			android:key="appTheme"
-			android:summary="Switch between dark and light theme"
+			android:summary="Switch between dark and light themes"
 			android:title="Theme" />
 		<CheckBoxPreference
 			android:defaultValue="false"


### PR DESCRIPTION
I also recommend changing the wording for "disambiguation dialog" to "open with dialogue" or "share sheet" or other term, as the word disambiguation won't mean anything to many people.